### PR TITLE
docker image version updated for envoy

### DIFF
--- a/images/envoy/Dockerfile
+++ b/images/envoy/Dockerfile
@@ -1,3 +1,3 @@
-FROM envoyproxy/envoy
+FROM envoyproxy/envoy:v1.29-latest
 
 COPY configs/envoy.yaml /etc/envoy/envoy.yaml


### PR DESCRIPTION
Nothing much.
Docker build failed on account of not finding latest. Specified the latest docker image available for envoy.